### PR TITLE
ヘッダー固定とロゴリンク追加

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,7 @@
-<header class="bg-amber-600 shadow-md p-4 flex items-center">
+<header class="bg-amber-600 shadow-md p-4 flex items-center sticky top-0">
   <div class="logo">
-    <%= image_tag "logo.png", alt: "ロゴ", class: "h-7" %>
+    <%= link_to root_path do %>
+      <%= image_tag "logo.png", alt: "ロゴ", class: "h-7" %>
+    <% end %>
   </div>
 </header>


### PR DESCRIPTION
# 概要
ヘッダーの固定およびロゴにリンクを追加

# 内容
ヘッダーをスクロールしてもページ上部から動かないように固定しました
ヘッダー左のロゴにリンクを追加しました。パスはroot_pathです。